### PR TITLE
Update libretro.c: Add input descriptor.

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -520,6 +520,7 @@ bool retro_load_game(const struct retro_game_info *info)
         {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_RIGHT,  "Right" },
         {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_START,  "Start" },
         {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_SELECT, "Pause" },
+        {0, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R, "Shutdown" },
         {0},
     };
     enum retro_pixel_format fmt = RETRO_PIXEL_FORMAT_RGB565;


### PR DESCRIPTION
The Shutdown action mapped to RetroPad R1 was missing an input descriptor.

Successfully compiled and tested on Windows 10 x64.