### PR TITLE
Set need_fullpath to true

### DIFF
--- a/libretro.c
+++ b/libretro.c
@@ -168,7 +168,7 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "pocketcdg";
-   info->need_fullpath    = false;
+   info->need_fullpath    = true;
    info->valid_extensions = "cdg";
 #ifdef GIT_VERSION
    info->library_version  = "git" GIT_VERSION;


### PR DESCRIPTION
## Description

This PR sets the libretro "need_fullpath" property to true. Files are opened with `fopen()` via the file path - there is no support for loading from memory, likely because both the audio file and the CDG file need to be adjacent to each other, so the full path must be known.

## Motivation and context

Problem was reported here: https://forum.kodi.tv/showthread.php?tid=351097&pid=3141500#pid3141500